### PR TITLE
MCP subscription monitors: connect page, token issuance, subscription management

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
       # Stripe Configuration
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
 
+      # Frontend base URL used to build the /connect setup link in emails
+      - FRONTEND_URL=${FRONTEND_URL:-https://app.teetimemonitor.com}
+
       # JVM Configuration
       - JAVA_OPTS=${JAVA_OPTS:--Xmx512m}
     restart: unless-stopped

--- a/pi-deployment/.env.example
+++ b/pi-deployment/.env.example
@@ -30,6 +30,9 @@ BB_PROJECT_ID=your_project_id
 # Stripe Configuration
 STRIPE_WEBHOOK_SECRET=your_stripe_webhook_secret
 
+# Frontend base URL for /connect setup links in emails
+FRONTEND_URL=https://app.teetimemonitor.com
+
 # Pi Configuration (auto-detected by deploy.sh)
 PI_IP=pi_ip
 

--- a/pi-deployment/docker-compose.yml
+++ b/pi-deployment/docker-compose.yml
@@ -49,6 +49,9 @@ services:
       - STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}
       - NOWGOLF_API_KEY=${NOWGOLF_API_KEY}
 
+      # Frontend base URL used to build the /connect setup link in emails
+      - FRONTEND_URL=${FRONTEND_URL:-https://app.teetimemonitor.com}
+
       # JVM Configuration
       - JAVA_OPTS=-Xms128m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=200
     restart: unless-stopped

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/ConnectApi.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/ConnectApi.java
@@ -1,0 +1,25 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.ResendConnectRequest;
+import com.hooswhere.letsgogolfing.dto.ResendConnectResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Validated
+@Tag(name = "Connect", description = "APIs supporting the connect/onboarding page")
+@RequestMapping("/api/connect")
+public interface ConnectApi {
+
+    @Operation(
+            summary = "Resend the connect setup link",
+            description = "Re-emails the /connect setup link to the address on file if it has an active " +
+                          "subscription. Always returns a generic 200 regardless of whether an account " +
+                          "exists, to avoid email enumeration."
+    )
+    @PostMapping("/resend")
+    ResendConnectResponse resend(@RequestBody ResendConnectRequest request);
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/ConnectController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/ConnectController.java
@@ -1,0 +1,32 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.ResendConnectRequest;
+import com.hooswhere.letsgogolfing.dto.ResendConnectResponse;
+import com.hooswhere.letsgogolfing.service.ConnectEmailService;
+import com.hooswhere.letsgogolfing.service.SubscriptionService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ConnectController implements ConnectApi {
+
+    private static final String GENERIC_MESSAGE =
+            "If you have an active subscription, we've emailed your setup link.";
+
+    private final SubscriptionService subscriptionService;
+    private final ConnectEmailService connectEmailService;
+
+    public ConnectController(SubscriptionService subscriptionService, ConnectEmailService connectEmailService) {
+        this.subscriptionService = subscriptionService;
+        this.connectEmailService = connectEmailService;
+    }
+
+    @Override
+    public ResendConnectResponse resend(ResendConnectRequest request) {
+        String email = request.email();
+        if (email != null && !email.isBlank()) {
+            subscriptionService.activeCheckoutSessionId(email)
+                    .ifPresent(sessionId -> connectEmailService.sendConnectEmail(email, sessionId));
+        }
+        return new ResendConnectResponse(GENERIC_MESSAGE);
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenApi.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenApi.java
@@ -1,5 +1,7 @@
 package com.hooswhere.letsgogolfing.controller;
 
+import com.hooswhere.letsgogolfing.dto.TokenIssueRequest;
+import com.hooswhere.letsgogolfing.dto.TokenIssueResponse;
 import com.hooswhere.letsgogolfing.dto.TokenResolveRequest;
 import com.hooswhere.letsgogolfing.dto.TokenResolveResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,4 +23,14 @@ public interface McpTokenApi {
     )
     @PostMapping("/resolve")
     TokenResolveResponse resolve(@RequestBody TokenResolveRequest request);
+
+    @Operation(
+            summary = "Issue a fresh MCP token",
+            description = "Rotates and returns a new per-user MCP token (revoking any prior token). " +
+                          "Requires an active subscription, otherwise returns 402. The raw token is " +
+                          "returned only here. Called by the connect-page worker after verifying a paid " +
+                          "Stripe checkout session."
+    )
+    @PostMapping("/issue")
+    TokenIssueResponse issue(@RequestBody TokenIssueRequest request);
 }

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenApi.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenApi.java
@@ -1,0 +1,24 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.TokenResolveRequest;
+import com.hooswhere.letsgogolfing.dto.TokenResolveResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Validated
+@Tag(name = "MCP Tokens", description = "APIs for resolving per-user MCP bearer tokens")
+@RequestMapping("/api/mcp/tokens")
+public interface McpTokenApi {
+
+    @Operation(
+            summary = "Resolve an MCP token",
+            description = "Resolves a per-user MCP token to its owner email and current subscription status. " +
+                          "Returns 401 if the token is unknown or revoked. Called by the MCP worker."
+    )
+    @PostMapping("/resolve")
+    TokenResolveResponse resolve(@RequestBody TokenResolveRequest request);
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenController.java
@@ -1,0 +1,28 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.TokenResolveRequest;
+import com.hooswhere.letsgogolfing.dto.TokenResolveResponse;
+import com.hooswhere.letsgogolfing.service.McpTokenService;
+import com.hooswhere.letsgogolfing.service.SubscriptionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class McpTokenController implements McpTokenApi {
+
+    private final McpTokenService mcpTokenService;
+    private final SubscriptionService subscriptionService;
+
+    public McpTokenController(McpTokenService mcpTokenService, SubscriptionService subscriptionService) {
+        this.mcpTokenService = mcpTokenService;
+        this.subscriptionService = subscriptionService;
+    }
+
+    @Override
+    public TokenResolveResponse resolve(TokenResolveRequest request) {
+        String email = mcpTokenService.resolveEmail(request.token())
+                .orElseThrow(() -> new LggException(HttpStatus.UNAUTHORIZED, "Invalid or revoked MCP token"));
+
+        return new TokenResolveResponse(email, subscriptionService.hasActiveSubscription(email));
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/McpTokenController.java
@@ -1,5 +1,7 @@
 package com.hooswhere.letsgogolfing.controller;
 
+import com.hooswhere.letsgogolfing.dto.TokenIssueRequest;
+import com.hooswhere.letsgogolfing.dto.TokenIssueResponse;
 import com.hooswhere.letsgogolfing.dto.TokenResolveRequest;
 import com.hooswhere.letsgogolfing.dto.TokenResolveResponse;
 import com.hooswhere.letsgogolfing.service.McpTokenService;
@@ -24,5 +26,18 @@ public class McpTokenController implements McpTokenApi {
                 .orElseThrow(() -> new LggException(HttpStatus.UNAUTHORIZED, "Invalid or revoked MCP token"));
 
         return new TokenResolveResponse(email, subscriptionService.hasActiveSubscription(email));
+    }
+
+    @Override
+    public TokenIssueResponse issue(TokenIssueRequest request) {
+        String email = request.email();
+        if (email == null || email.isBlank()) {
+            throw new LggException(HttpStatus.BAD_REQUEST, "email is required");
+        }
+        if (!subscriptionService.hasActiveSubscription(email)) {
+            throw new LggException(HttpStatus.PAYMENT_REQUIRED, "No active subscription for " + email);
+        }
+
+        return new TokenIssueResponse(mcpTokenService.issueToken(email));
     }
 }

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/MonitorApi.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/MonitorApi.java
@@ -1,0 +1,32 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.CreateMonitorRequest;
+import com.hooswhere.letsgogolfing.dto.UserSearchPreferenceDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Validated
+@Tag(name = "Monitors", description = "Subscription-gated server-side creation of tee time monitors (used by the MCP server)")
+@RequestMapping("/api/monitors")
+public interface MonitorApi {
+
+    @Operation(
+            summary = "Create a tee time monitor",
+            description = "Creates a search preference and starts its monitoring schedule for the given user. " +
+                          "Requires an active subscription (402 otherwise). Enforces one active monitor per user " +
+                          "(409 with error 'monitor_exists' unless replace=true, which replaces the existing one)."
+    )
+    @PostMapping
+    ResponseEntity<UserSearchPreferenceDto> createMonitor(
+            @RequestBody CreateMonitorRequest request,
+            @Parameter(description = "Replace the user's existing active monitor instead of failing", example = "false")
+            @RequestParam(defaultValue = "false") boolean replace
+    );
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/MonitorController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/MonitorController.java
@@ -1,0 +1,91 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.CreateMonitorRequest;
+import com.hooswhere.letsgogolfing.dto.SearchCriteria;
+import com.hooswhere.letsgogolfing.dto.UserSearchPreferenceDto;
+import com.hooswhere.letsgogolfing.service.MonitorCreationService;
+import com.hooswhere.letsgogolfing.service.SubscriptionService;
+import com.hooswhere.letsgogolfing.service.TeeTimeScheduleStarter;
+import com.hooswhere.letsgogolfing.service.UserSearchPreferenceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.util.List;
+
+@RestController
+public class MonitorController implements MonitorApi {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MonitorController.class);
+    private static final Duration DEFAULT_INTERVAL = Duration.ofMinutes(5);
+
+    private final SubscriptionService subscriptionService;
+    private final UserSearchPreferenceService userSearchPreferenceService;
+    private final MonitorCreationService monitorCreationService;
+    private final TeeTimeScheduleStarter scheduleStarter;
+
+    public MonitorController(SubscriptionService subscriptionService,
+                             UserSearchPreferenceService userSearchPreferenceService,
+                             MonitorCreationService monitorCreationService,
+                             TeeTimeScheduleStarter scheduleStarter) {
+        this.subscriptionService = subscriptionService;
+        this.userSearchPreferenceService = userSearchPreferenceService;
+        this.monitorCreationService = monitorCreationService;
+        this.scheduleStarter = scheduleStarter;
+    }
+
+    @Override
+    @Transactional
+    public ResponseEntity<UserSearchPreferenceDto> createMonitor(CreateMonitorRequest request, boolean replace) {
+        String email = request.email();
+        if (email == null || email.isBlank()) {
+            throw new LggException(HttpStatus.BAD_REQUEST, "email is required");
+        }
+        if (request.searchCriteria() == null) {
+            throw new LggException(HttpStatus.BAD_REQUEST, "searchCriteria is required");
+        }
+
+        if (!subscriptionService.hasActiveSubscription(email)) {
+            throw new LggException(HttpStatus.PAYMENT_REQUIRED, "no_active_subscription");
+        }
+
+        // One active monitor per user. Replace tears down the old one first.
+        List<UserSearchPreferenceDto> existing = userSearchPreferenceService.getActivePreferences(email);
+        if (!existing.isEmpty()) {
+            if (!replace) {
+                throw new LggException(HttpStatus.CONFLICT, "monitor_exists");
+            }
+            replaceExisting(email, existing);
+        }
+
+        UserSearchPreferenceDto pref = monitorCreationService.createFromCriteria(
+                email, request.searchCriteria(), intervalFor(request.searchCriteria()));
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(pref);
+    }
+
+    private void replaceExisting(String email, List<UserSearchPreferenceDto> existing) {
+        // The schedule is keyed by email, so deleting once is enough. It may already be gone
+        // (e.g. expired), so a NOT_FOUND here is fine.
+        try {
+            scheduleStarter.deleteTeeTimeSearchSchedule(email);
+        } catch (ResponseStatusException e) {
+            if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
+                throw e;
+            }
+            LOG.info("No existing schedule to delete for {} during replace", email);
+        }
+        existing.forEach(pref -> userSearchPreferenceService.deactivatePreference(pref.id()));
+    }
+
+    private Duration intervalFor(SearchCriteria criteria) {
+        return criteria.checkIntervalMinutes() > 0
+                ? Duration.ofMinutes(criteria.checkIntervalMinutes())
+                : DEFAULT_INTERVAL;
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/StripeWebhookController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/StripeWebhookController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class StripeWebhookController implements StripeWebhookApi {
     private static final Logger LOG = LoggerFactory.getLogger(StripeWebhookController.class);
-    private static final String CHECKOUT_SESSION_COMPLETED = "checkout.session.completed";
 
     private final StripeWebhookService webhookService;
 
@@ -27,12 +26,14 @@ public class StripeWebhookController implements StripeWebhookApi {
 
             LOG.info("Received Stripe webhook event: {}", event.getType());
 
-            // Handle checkout.session.completed event
-            if (CHECKOUT_SESSION_COMPLETED.equals(event.getType())) {
-                webhookService.processCheckoutCompleted(event);
-                LOG.info("Successfully processed checkout completion");
-            } else {
-                LOG.info("Ignoring webhook event type: {}", event.getType());
+            switch (event.getType()) {
+                // One-time checkout (web UI) and subscription checkout (MCP) both land here;
+                // processCheckoutCompleted branches on session.mode.
+                case "checkout.session.completed" -> webhookService.processCheckoutCompleted(event);
+                case "customer.subscription.created",
+                     "customer.subscription.updated",
+                     "customer.subscription.deleted" -> webhookService.processSubscriptionEvent(event);
+                default -> LOG.info("Ignoring webhook event type: {}", event.getType());
             }
 
             return ResponseEntity.ok().build();

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/SubscriptionApi.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/SubscriptionApi.java
@@ -1,0 +1,27 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.SubscriptionStatusDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Validated
+@Tag(name = "Subscriptions", description = "APIs for checking recurring subscription status")
+@RequestMapping("/api/subscription")
+public interface SubscriptionApi {
+
+    @Operation(
+            summary = "Get subscription status for a user",
+            description = "Returns whether the user has an active recurring subscription, the raw status, " +
+                          "and the current period end."
+    )
+    @GetMapping("/status")
+    SubscriptionStatusDto getStatus(
+            @Parameter(description = "User email address", required = true, example = "user@example.com")
+            @RequestParam String email
+    );
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/SubscriptionController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/SubscriptionController.java
@@ -1,0 +1,20 @@
+package com.hooswhere.letsgogolfing.controller;
+
+import com.hooswhere.letsgogolfing.dto.SubscriptionStatusDto;
+import com.hooswhere.letsgogolfing.service.SubscriptionService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SubscriptionController implements SubscriptionApi {
+
+    private final SubscriptionService subscriptionService;
+
+    public SubscriptionController(SubscriptionService subscriptionService) {
+        this.subscriptionService = subscriptionService;
+    }
+
+    @Override
+    public SubscriptionStatusDto getStatus(String email) {
+        return subscriptionService.getStatus(email);
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/controller/UserSearchController.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/controller/UserSearchController.java
@@ -2,11 +2,13 @@ package com.hooswhere.letsgogolfing.controller;
 
 import com.hooswhere.letsgogolfing.dto.CreateUserSearchRequest;
 import com.hooswhere.letsgogolfing.dto.UserSearchPreferenceDto;
+import com.hooswhere.letsgogolfing.service.TeeTimeScheduleStarter;
 import com.hooswhere.letsgogolfing.service.UserSearchPreferenceService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 import java.util.UUID;
@@ -14,10 +16,15 @@ import java.util.UUID;
 @RestController
 public class UserSearchController implements UserSearchApi {
 
-    private final UserSearchPreferenceService userSearchPreferenceService;
+    private static final Logger LOG = LoggerFactory.getLogger(UserSearchController.class);
 
-    public UserSearchController(UserSearchPreferenceService userSearchPreferenceService) {
+    private final UserSearchPreferenceService userSearchPreferenceService;
+    private final TeeTimeScheduleStarter scheduleStarter;
+
+    public UserSearchController(UserSearchPreferenceService userSearchPreferenceService,
+                                TeeTimeScheduleStarter scheduleStarter) {
         this.userSearchPreferenceService = userSearchPreferenceService;
+        this.scheduleStarter = scheduleStarter;
     }
 
     @Override
@@ -48,6 +55,16 @@ public class UserSearchController implements UserSearchApi {
 
     @Override
     public void deleteSearch(UUID id) {
+        // Stop the Temporal schedule (keyed by email) before deactivating the preference.
+        UserSearchPreferenceDto pref = userSearchPreferenceService.getPreference(id);
+        try {
+            scheduleStarter.deleteTeeTimeSearchSchedule(pref.email());
+        } catch (ResponseStatusException e) {
+            if (e.getStatusCode() != HttpStatus.NOT_FOUND) {
+                throw e;
+            }
+            LOG.info("No schedule to delete for {} when cancelling monitor {}", pref.email(), id);
+        }
         userSearchPreferenceService.deactivatePreference(id);
     }
 }

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/CreateMonitorRequest.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/CreateMonitorRequest.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record CreateMonitorRequest(String email, SearchCriteria searchCriteria) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/ResendConnectRequest.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/ResendConnectRequest.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record ResendConnectRequest(String email) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/ResendConnectResponse.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/ResendConnectResponse.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record ResendConnectResponse(String message) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/SubscriptionStatusDto.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/SubscriptionStatusDto.java
@@ -1,0 +1,6 @@
+package com.hooswhere.letsgogolfing.dto;
+
+import java.time.Instant;
+
+public record SubscriptionStatusDto(boolean active, String status, Instant currentPeriodEnd) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/TokenIssueRequest.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/TokenIssueRequest.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record TokenIssueRequest(String email) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/TokenIssueResponse.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/TokenIssueResponse.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record TokenIssueResponse(String token) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/TokenResolveRequest.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/TokenResolveRequest.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record TokenResolveRequest(String token) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/dto/TokenResolveResponse.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/dto/TokenResolveResponse.java
@@ -1,0 +1,4 @@
+package com.hooswhere.letsgogolfing.dto;
+
+public record TokenResolveResponse(String email, boolean subscriptionActive) {
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/entity/McpTokenEntity.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/entity/McpTokenEntity.java
@@ -1,0 +1,86 @@
+package com.hooswhere.letsgogolfing.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "mcp_tokens")
+public class McpTokenEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 128)
+    private String tokenHash;
+
+    @Column(nullable = false)
+    private boolean revoked;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "last_used_at")
+    private LocalDateTime lastUsedAt;
+
+    public McpTokenEntity() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getTokenHash() {
+        return tokenHash;
+    }
+
+    public void setTokenHash(String tokenHash) {
+        this.tokenHash = tokenHash;
+    }
+
+    public boolean isRevoked() {
+        return revoked;
+    }
+
+    public void setRevoked(boolean revoked) {
+        this.revoked = revoked;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getLastUsedAt() {
+        return lastUsedAt;
+    }
+
+    public void setLastUsedAt(LocalDateTime lastUsedAt) {
+        this.lastUsedAt = lastUsedAt;
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/entity/SubscriptionEntity.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/entity/SubscriptionEntity.java
@@ -28,6 +28,9 @@ public class SubscriptionEntity {
     @Column(name = "stripe_subscription_id", unique = true)
     private String stripeSubscriptionId;
 
+    @Column(name = "stripe_checkout_session_id")
+    private String stripeCheckoutSessionId;
+
     @Column(nullable = false, length = 32)
     private String status;
 
@@ -81,6 +84,14 @@ public class SubscriptionEntity {
 
     public void setStripeSubscriptionId(String stripeSubscriptionId) {
         this.stripeSubscriptionId = stripeSubscriptionId;
+    }
+
+    public String getStripeCheckoutSessionId() {
+        return stripeCheckoutSessionId;
+    }
+
+    public void setStripeCheckoutSessionId(String stripeCheckoutSessionId) {
+        this.stripeCheckoutSessionId = stripeCheckoutSessionId;
     }
 
     public String getStatus() {

--- a/src/main/java/com/hooswhere/letsgogolfing/entity/SubscriptionEntity.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/entity/SubscriptionEntity.java
@@ -1,0 +1,125 @@
+package com.hooswhere.letsgogolfing.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "subscriptions")
+public class SubscriptionEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(name = "stripe_customer_id")
+    private String stripeCustomerId;
+
+    @Column(name = "stripe_subscription_id", unique = true)
+    private String stripeSubscriptionId;
+
+    @Column(nullable = false, length = 32)
+    private String status;
+
+    @Column(name = "current_period_end")
+    private LocalDateTime currentPeriodEnd;
+
+    @Column(name = "cancel_at_period_end", nullable = false)
+    private boolean cancelAtPeriodEnd;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt = LocalDateTime.now();
+
+    public SubscriptionEntity() {
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getStripeCustomerId() {
+        return stripeCustomerId;
+    }
+
+    public void setStripeCustomerId(String stripeCustomerId) {
+        this.stripeCustomerId = stripeCustomerId;
+    }
+
+    public String getStripeSubscriptionId() {
+        return stripeSubscriptionId;
+    }
+
+    public void setStripeSubscriptionId(String stripeSubscriptionId) {
+        this.stripeSubscriptionId = stripeSubscriptionId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public LocalDateTime getCurrentPeriodEnd() {
+        return currentPeriodEnd;
+    }
+
+    public void setCurrentPeriodEnd(LocalDateTime currentPeriodEnd) {
+        this.currentPeriodEnd = currentPeriodEnd;
+    }
+
+    public boolean isCancelAtPeriodEnd() {
+        return cancelAtPeriodEnd;
+    }
+
+    public void setCancelAtPeriodEnd(boolean cancelAtPeriodEnd) {
+        this.cancelAtPeriodEnd = cancelAtPeriodEnd;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/repository/McpTokenRepository.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/repository/McpTokenRepository.java
@@ -1,0 +1,17 @@
+package com.hooswhere.letsgogolfing.repository;
+
+import com.hooswhere.letsgogolfing.entity.McpTokenEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface McpTokenRepository extends JpaRepository<McpTokenEntity, UUID> {
+
+    Optional<McpTokenEntity> findByTokenHash(String tokenHash);
+
+    List<McpTokenEntity> findByEmailAndRevokedFalse(String email);
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/repository/SubscriptionRepository.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/repository/SubscriptionRepository.java
@@ -1,0 +1,17 @@
+package com.hooswhere.letsgogolfing.repository;
+
+import com.hooswhere.letsgogolfing.entity.SubscriptionEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SubscriptionRepository extends JpaRepository<SubscriptionEntity, UUID> {
+
+    Optional<SubscriptionEntity> findByStripeSubscriptionId(String stripeSubscriptionId);
+
+    List<SubscriptionEntity> findByEmailOrderByCreatedAtDesc(String email);
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/service/ConnectEmailService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/ConnectEmailService.java
@@ -1,0 +1,55 @@
+package com.hooswhere.letsgogolfing.service;
+
+import com.hooswhere.letsgogolfing.notification.email.EmailService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Sends the post-subscription "set up your access" email. The email links to the frontend
+ * /connect page (carrying the Stripe checkout session id) rather than embedding a raw token:
+ * the connect page is the single source of truth and issues the token on visit.
+ */
+@Service
+public class ConnectEmailService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ConnectEmailService.class);
+
+    @Value("${app.frontend-url}")
+    private String frontendUrl;
+
+    private final EmailService emailService;
+
+    public ConnectEmailService(EmailService emailService) {
+        this.emailService = emailService;
+    }
+
+    public void sendConnectEmail(String email, String checkoutSessionId) {
+        String connectUrl = frontendUrl + "/connect?session_id="
+                + URLEncoder.encode(checkoutSessionId, StandardCharsets.UTF_8);
+        String subject = "Set up your tee-time monitor access";
+        String textBody = """
+                You're all set! Your subscription is active.
+
+                Finish connecting your AI assistant here:
+                %s
+
+                This page shows your personal access token and copy-paste setup steps for
+                Claude Desktop, Claude Code, and the Claude mobile/web app. You can also manage or
+                cancel your subscription from there.
+
+                Keep this link private - it's tied to your account.
+                """.formatted(connectUrl);
+
+        boolean sent = emailService.sendEmail(email, subject, null, textBody);
+        if (sent) {
+            LOG.info("Connect email sent to {}", email);
+        } else {
+            LOG.warn("Failed to send connect email to {}", email);
+        }
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/service/McpTokenService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/McpTokenService.java
@@ -1,0 +1,102 @@
+package com.hooswhere.letsgogolfing.service;
+
+import com.hooswhere.letsgogolfing.entity.McpTokenEntity;
+import com.hooswhere.letsgogolfing.repository.McpTokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Optional;
+
+@Service
+public class McpTokenService {
+
+    private static final String TOKEN_PREFIX = "mcp_";
+    private static final int TOKEN_BYTES = 32;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+    private final McpTokenRepository mcpTokenRepository;
+
+    public McpTokenService(McpTokenRepository mcpTokenRepository) {
+        this.mcpTokenRepository = mcpTokenRepository;
+    }
+
+    /**
+     * Generates a new high-entropy token for the user, storing only its hash.
+     * Existing tokens for the email are revoked so each issue replaces the last.
+     * Returns the raw token, which is only available here and never persisted.
+     */
+    @Transactional
+    public String issueToken(String email) {
+        mcpTokenRepository.findByEmailAndRevokedFalse(email).forEach(token -> {
+            token.setRevoked(true);
+            mcpTokenRepository.save(token);
+        });
+
+        byte[] randomBytes = new byte[TOKEN_BYTES];
+        secureRandom.nextBytes(randomBytes);
+        String rawToken = TOKEN_PREFIX + Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+
+        McpTokenEntity entity = new McpTokenEntity();
+        entity.setEmail(email);
+        entity.setTokenHash(hash(rawToken));
+        entity.setRevoked(false);
+        mcpTokenRepository.save(entity);
+
+        return rawToken;
+    }
+
+    /**
+     * Issues a token only if the user has no active token yet. Used by the webhook so that
+     * redelivered checkout events don't churn the user's token. Returns the raw token when a
+     * new one was created, empty otherwise.
+     */
+    @Transactional
+    public Optional<String> issueTokenIfAbsent(String email) {
+        if (!mcpTokenRepository.findByEmailAndRevokedFalse(email).isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(issueToken(email));
+    }
+
+    /**
+     * Resolves a raw token to its owner email, touching last_used_at.
+     * Returns empty if the token is unknown or revoked.
+     */
+    @Transactional
+    public Optional<String> resolveEmail(String rawToken) {
+        if (rawToken == null || rawToken.isBlank()) {
+            return Optional.empty();
+        }
+        return mcpTokenRepository.findByTokenHash(hash(rawToken))
+                .filter(token -> !token.isRevoked())
+                .map(token -> {
+                    token.setLastUsedAt(LocalDateTime.now());
+                    mcpTokenRepository.save(token);
+                    return token.getEmail();
+                });
+    }
+
+    @Transactional
+    public void revokeForEmail(String email) {
+        mcpTokenRepository.findByEmailAndRevokedFalse(email).forEach(token -> {
+            token.setRevoked(true);
+            mcpTokenRepository.save(token);
+        });
+    }
+
+    private String hash(String rawToken) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashed = digest.digest(rawToken.getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hashed);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/service/McpTokenService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/McpTokenService.java
@@ -52,19 +52,6 @@ public class McpTokenService {
     }
 
     /**
-     * Issues a token only if the user has no active token yet. Used by the webhook so that
-     * redelivered checkout events don't churn the user's token. Returns the raw token when a
-     * new one was created, empty otherwise.
-     */
-    @Transactional
-    public Optional<String> issueTokenIfAbsent(String email) {
-        if (!mcpTokenRepository.findByEmailAndRevokedFalse(email).isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(issueToken(email));
-    }
-
-    /**
      * Resolves a raw token to its owner email, touching last_used_at.
      * Returns empty if the token is unknown or revoked.
      */

--- a/src/main/java/com/hooswhere/letsgogolfing/service/MonitorCreationService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/MonitorCreationService.java
@@ -1,0 +1,46 @@
+package com.hooswhere.letsgogolfing.service;
+
+import com.hooswhere.letsgogolfing.dto.SearchCriteria;
+import com.hooswhere.letsgogolfing.dto.UserSearchPreferenceDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Shared "create a search preference and start its monitoring schedule" logic, used by both the
+ * Stripe webhook (one-time checkout) and the subscription-gated /api/monitors endpoint.
+ */
+@Service
+public class MonitorCreationService {
+
+    private final UserSearchPreferenceService userSearchPreferenceService;
+    private final TeeTimeScheduleStarter scheduleStarter;
+
+    public MonitorCreationService(UserSearchPreferenceService userSearchPreferenceService,
+                                  TeeTimeScheduleStarter scheduleStarter) {
+        this.userSearchPreferenceService = userSearchPreferenceService;
+        this.scheduleStarter = scheduleStarter;
+    }
+
+    @Transactional
+    public UserSearchPreferenceDto createFromCriteria(String email, SearchCriteria criteria, Duration interval) {
+        UserSearchPreferenceDto pref = userSearchPreferenceService.createPreference(email, criteria, false, true, interval);
+        return startSchedule(pref);
+    }
+
+    @Transactional
+    public UserSearchPreferenceDto createFromCriteriaId(String email, UUID searchCriteriaId, Duration interval) {
+        UserSearchPreferenceDto pref = userSearchPreferenceService.createPreferenceFromCriteriaId(
+                email, searchCriteriaId, false, true, interval);
+        return startSchedule(pref);
+    }
+
+    private UserSearchPreferenceDto startSchedule(UserSearchPreferenceDto pref) {
+        Optional<String> scheduleId = scheduleStarter.createTeeTimeSearchSchedule(pref);
+        scheduleId.ifPresent(id -> userSearchPreferenceService.updateScheduleId(pref.id(), id));
+        return userSearchPreferenceService.getPreference(pref.id());
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/service/StripeWebhookService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/StripeWebhookService.java
@@ -42,7 +42,7 @@ public class StripeWebhookService {
     private final EmailService emailService;
     private final EmailTemplateService emailTemplateService;
     private final SubscriptionService subscriptionService;
-    private final McpTokenService mcpTokenService;
+    private final ConnectEmailService connectEmailService;
 
     public StripeWebhookService(UserSearchPreferenceService userSearchPreferenceService,
                                 SearchCriteriaRepository searchCriteriaRepository,
@@ -50,14 +50,14 @@ public class StripeWebhookService {
                                 EmailService emailService,
                                 EmailTemplateService emailTemplateService,
                                 SubscriptionService subscriptionService,
-                                McpTokenService mcpTokenService) {
+                                ConnectEmailService connectEmailService) {
         this.userSearchPreferenceService = userSearchPreferenceService;
         this.searchCriteriaRepository = searchCriteriaRepository;
         this.monitorCreationService = monitorCreationService;
         this.emailService = emailService;
         this.emailTemplateService = emailTemplateService;
         this.subscriptionService = subscriptionService;
-        this.mcpTokenService = mcpTokenService;
+        this.connectEmailService = connectEmailService;
     }
 
     /**
@@ -124,8 +124,9 @@ public class StripeWebhookService {
     }
 
     /**
-     * Handles a completed subscription checkout: records the subscription as active and issues an
-     * MCP token (emailed to the user) so they can connect an AI agent.
+     * Handles a completed subscription checkout: records the subscription as active (storing the
+     * checkout session id) and emails the user a link to the /connect page, where they issue their
+     * MCP token and finish setup.
      */
     private void processSubscriptionCheckout(Session session) {
         String email = session.getCustomerDetails() != null
@@ -143,11 +144,9 @@ public class StripeWebhookService {
 
         LOG.info("Processing subscription checkout for {} (subscription {})", email, subscriptionId);
 
-        subscriptionService.upsertFromStripe(subscriptionId, customerId, email, "active", null, false);
+        subscriptionService.upsertFromStripe(subscriptionId, customerId, session.getId(), email, "active", null, false);
 
-        // Only email a token if the user doesn't already have one (idempotent on redelivery).
-        mcpTokenService.issueTokenIfAbsent(email)
-                .ifPresent(token -> sendMcpTokenEmail(email, token));
+        connectEmailService.sendConnectEmail(email, session.getId());
     }
 
     /**
@@ -168,6 +167,7 @@ public class StripeWebhookService {
         subscriptionService.upsertFromStripe(
                 sub.getId(),
                 sub.getCustomer(),
+                null,                 // no checkout session on subscription events; existing row keeps it
                 null,                 // email not present on subscription events; existing row keeps it
                 status,
                 currentPeriodEnd(sub),
@@ -186,31 +186,6 @@ public class StripeWebhookService {
         return epochSeconds != null
                 ? LocalDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC)
                 : null;
-    }
-
-    private void sendMcpTokenEmail(String email, String token) {
-        String subject = "Your tee-time monitor access token";
-        String connectorUrl = "https://tee-time-mcp.smaldore.dev/mcp?token=" + token;
-        String textBody = """
-                You're all set! Your subscription is active.
-
-                To monitor tee times from an AI agent, connect to the tee-time MCP server.
-
-                Mobile / web (Claude app -> add connector), paste this URL:
-                %s
-
-                Coding agents / desktop, use a header instead:
-                Authorization: Bearer %s
-
-                Keep this token secret. It identifies your account.
-                """.formatted(connectorUrl, token);
-
-        boolean sent = emailService.sendEmail(email, subject, null, textBody);
-        if (sent) {
-            LOG.info("MCP token email sent to {}", email);
-        } else {
-            LOG.warn("Failed to send MCP token email to {}", email);
-        }
     }
 
     private void sendPaymentConfirmationEmail(String email, SearchCriteriaEntity criteria) {

--- a/src/main/java/com/hooswhere/letsgogolfing/service/StripeWebhookService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/StripeWebhookService.java
@@ -10,6 +10,8 @@ import com.hooswhere.letsgogolfing.notification.email.EmailTemplateService;
 import com.hooswhere.letsgogolfing.repository.SearchCriteriaRepository;
 import com.stripe.exception.SignatureVerificationException;
 import com.stripe.model.Event;
+import com.stripe.model.Subscription;
+import com.stripe.model.SubscriptionItem;
 import com.stripe.model.checkout.Session;
 import com.stripe.net.Webhook;
 import org.slf4j.Logger;
@@ -19,6 +21,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -32,20 +38,26 @@ public class StripeWebhookService {
 
     private final UserSearchPreferenceService userSearchPreferenceService;
     private final SearchCriteriaRepository searchCriteriaRepository;
-    private final TeeTimeScheduleStarter scheduleStarter;
+    private final MonitorCreationService monitorCreationService;
     private final EmailService emailService;
     private final EmailTemplateService emailTemplateService;
+    private final SubscriptionService subscriptionService;
+    private final McpTokenService mcpTokenService;
 
     public StripeWebhookService(UserSearchPreferenceService userSearchPreferenceService,
                                 SearchCriteriaRepository searchCriteriaRepository,
-                                TeeTimeScheduleStarter scheduleStarter,
+                                MonitorCreationService monitorCreationService,
                                 EmailService emailService,
-                                EmailTemplateService emailTemplateService) {
+                                EmailTemplateService emailTemplateService,
+                                SubscriptionService subscriptionService,
+                                McpTokenService mcpTokenService) {
         this.userSearchPreferenceService = userSearchPreferenceService;
         this.searchCriteriaRepository = searchCriteriaRepository;
-        this.scheduleStarter = scheduleStarter;
+        this.monitorCreationService = monitorCreationService;
         this.emailService = emailService;
         this.emailTemplateService = emailTemplateService;
+        this.subscriptionService = subscriptionService;
+        this.mcpTokenService = mcpTokenService;
     }
 
     /**
@@ -65,6 +77,12 @@ public class StripeWebhookService {
         Session session = (Session) event.getDataObjectDeserializer().getObject().orElseThrow(
                 () -> new IllegalArgumentException("Could not deserialize checkout session from webhook")
         );
+
+        // Subscription checkouts (MCP access) and one-time checkouts (web UI) both arrive here.
+        if ("subscription".equals(session.getMode())) {
+            processSubscriptionCheckout(session);
+            return;
+        }
 
         // Extract data from session
         String email = session.getCustomerDetails().getEmail();
@@ -97,28 +115,101 @@ public class StripeWebhookService {
             return;
         }
 
-        // Create user search preference
-        UserSearchPreferenceDto userPref = userSearchPreferenceService.createPreferenceFromCriteriaId(
-                email,
-                searchCriteriaId,
-                false,  // payment_enabled = false (determines if workflow auto-pays on GolfNow)
-                true,   // notify_enabled = true
-                Duration.parse("PT5M")  // schedule_interval = 5 minutes
+        // Create the preference and start its monitoring schedule (shared with /api/monitors)
+        UserSearchPreferenceDto userPref = monitorCreationService.createFromCriteriaId(
+                email, searchCriteriaId, Duration.parse("PT5M"));
+
+        LOG.info("Started schedule {} for user {}", userPref.scheduleId(), email);
+        sendPaymentConfirmationEmail(email, searchCriteria);
+    }
+
+    /**
+     * Handles a completed subscription checkout: records the subscription as active and issues an
+     * MCP token (emailed to the user) so they can connect an AI agent.
+     */
+    private void processSubscriptionCheckout(Session session) {
+        String email = session.getCustomerDetails() != null
+                ? session.getCustomerDetails().getEmail()
+                : session.getCustomerEmail();
+        String customerId = session.getCustomer();
+        String subscriptionId = session.getSubscription();
+
+        if (email == null || email.isBlank()) {
+            throw new IllegalArgumentException("Email not found in subscription checkout session");
+        }
+        if (subscriptionId == null || subscriptionId.isBlank()) {
+            throw new IllegalArgumentException("Subscription id not found in checkout session");
+        }
+
+        LOG.info("Processing subscription checkout for {} (subscription {})", email, subscriptionId);
+
+        subscriptionService.upsertFromStripe(subscriptionId, customerId, email, "active", null, false);
+
+        // Only email a token if the user doesn't already have one (idempotent on redelivery).
+        mcpTokenService.issueTokenIfAbsent(email)
+                .ifPresent(token -> sendMcpTokenEmail(email, token));
+    }
+
+    /**
+     * Handles customer.subscription.created/updated/deleted. Looks up the row by subscription id
+     * (no email on these events) and updates status / period end / cancellation.
+     */
+    @Transactional
+    public void processSubscriptionEvent(Event event) {
+        Subscription sub = (Subscription) event.getDataObjectDeserializer().getObject().orElseThrow(
+                () -> new IllegalArgumentException("Could not deserialize subscription from webhook")
         );
 
-        LOG.info("Created user search preference with ID: {}", userPref.id());
+        String status = "customer.subscription.deleted".equals(event.getType()) ? "canceled" : sub.getStatus();
+        boolean cancelAtPeriodEnd = Boolean.TRUE.equals(sub.getCancelAtPeriodEnd());
 
-        // Start Temporal schedule
-        var scheduleResponse = scheduleStarter.createTeeTimeSearchSchedule(userPref);
+        LOG.info("Processing {} for subscription {} (status {})", event.getType(), sub.getId(), status);
 
-        if (scheduleResponse.isPresent()) {
-            String scheduleId = scheduleResponse.get();
-            userSearchPreferenceService.updateScheduleId(userPref.id(), scheduleId);
-            LOG.info("Successfully started schedule {} for user {}", scheduleId, email);
-            sendPaymentConfirmationEmail(email, searchCriteria);
+        subscriptionService.upsertFromStripe(
+                sub.getId(),
+                sub.getCustomer(),
+                null,                 // email not present on subscription events; existing row keeps it
+                status,
+                currentPeriodEnd(sub),
+                cancelAtPeriodEnd);
+    }
+
+    private LocalDateTime currentPeriodEnd(Subscription sub) {
+        if (sub.getItems() == null) {
+            return null;
+        }
+        List<SubscriptionItem> items = sub.getItems().getData();
+        if (items == null || items.isEmpty()) {
+            return null;
+        }
+        Long epochSeconds = items.get(0).getCurrentPeriodEnd();
+        return epochSeconds != null
+                ? LocalDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC)
+                : null;
+    }
+
+    private void sendMcpTokenEmail(String email, String token) {
+        String subject = "Your tee-time monitor access token";
+        String connectorUrl = "https://tee-time-mcp.smaldore.dev/mcp?token=" + token;
+        String textBody = """
+                You're all set! Your subscription is active.
+
+                To monitor tee times from an AI agent, connect to the tee-time MCP server.
+
+                Mobile / web (Claude app -> add connector), paste this URL:
+                %s
+
+                Coding agents / desktop, use a header instead:
+                Authorization: Bearer %s
+
+                Keep this token secret. It identifies your account.
+                """.formatted(connectorUrl, token);
+
+        boolean sent = emailService.sendEmail(email, subject, null, textBody);
+        if (sent) {
+            LOG.info("MCP token email sent to {}", email);
         } else {
-            LOG.error("Failed to create schedule for user {}", email);
-            throw new RuntimeException("Failed to create monitoring schedule");
+            LOG.warn("Failed to send MCP token email to {}", email);
         }
     }
 

--- a/src/main/java/com/hooswhere/letsgogolfing/service/SubscriptionService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/SubscriptionService.java
@@ -42,6 +42,19 @@ public class SubscriptionService {
     }
 
     /**
+     * Returns the checkout session id of the user's active subscription, used to rebuild their
+     * /connect link for the "resend setup link" recovery flow. Empty if no active subscription
+     * or no stored session id.
+     */
+    @Transactional(readOnly = true)
+    public Optional<String> activeCheckoutSessionId(String email) {
+        return mostRecent(email)
+                .filter(this::isActive)
+                .map(SubscriptionEntity::getStripeCheckoutSessionId)
+                .filter(id -> id != null && !id.isBlank());
+    }
+
+    /**
      * Creates or updates a subscription row keyed by Stripe subscription ID.
      * When email is null (e.g. subscription.updated/deleted events that lack it), the
      * existing email is preserved.
@@ -49,6 +62,7 @@ public class SubscriptionService {
     @Transactional
     public void upsertFromStripe(String stripeSubscriptionId,
                                  String stripeCustomerId,
+                                 String stripeCheckoutSessionId,
                                  String email,
                                  String status,
                                  LocalDateTime currentPeriodEnd,
@@ -66,6 +80,9 @@ public class SubscriptionService {
         sub.setStripeSubscriptionId(stripeSubscriptionId);
         if (stripeCustomerId != null) {
             sub.setStripeCustomerId(stripeCustomerId);
+        }
+        if (stripeCheckoutSessionId != null) {
+            sub.setStripeCheckoutSessionId(stripeCheckoutSessionId);
         }
         if (email != null) {
             sub.setEmail(email);

--- a/src/main/java/com/hooswhere/letsgogolfing/service/SubscriptionService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/SubscriptionService.java
@@ -1,0 +1,92 @@
+package com.hooswhere.letsgogolfing.service;
+
+import com.hooswhere.letsgogolfing.dto.SubscriptionStatusDto;
+import com.hooswhere.letsgogolfing.entity.SubscriptionEntity;
+import com.hooswhere.letsgogolfing.repository.SubscriptionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+@Service
+public class SubscriptionService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SubscriptionService.class);
+    private static final Set<String> ACTIVE_STATUSES = Set.of("active", "trialing");
+
+    private final SubscriptionRepository subscriptionRepository;
+
+    public SubscriptionService(SubscriptionRepository subscriptionRepository) {
+        this.subscriptionRepository = subscriptionRepository;
+    }
+
+    @Transactional(readOnly = true)
+    public SubscriptionStatusDto getStatus(String email) {
+        return mostRecent(email)
+                .map(sub -> new SubscriptionStatusDto(
+                        isActive(sub),
+                        sub.getStatus(),
+                        sub.getCurrentPeriodEnd() != null ? sub.getCurrentPeriodEnd().toInstant(ZoneOffset.UTC) : null))
+                .orElse(new SubscriptionStatusDto(false, "none", null));
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasActiveSubscription(String email) {
+        return mostRecent(email).map(this::isActive).orElse(false);
+    }
+
+    /**
+     * Creates or updates a subscription row keyed by Stripe subscription ID.
+     * When email is null (e.g. subscription.updated/deleted events that lack it), the
+     * existing email is preserved.
+     */
+    @Transactional
+    public void upsertFromStripe(String stripeSubscriptionId,
+                                 String stripeCustomerId,
+                                 String email,
+                                 String status,
+                                 LocalDateTime currentPeriodEnd,
+                                 boolean cancelAtPeriodEnd) {
+        Optional<SubscriptionEntity> existing = subscriptionRepository.findByStripeSubscriptionId(stripeSubscriptionId);
+        if (existing.isEmpty() && email == null) {
+            // A subscription.updated/deleted event arrived before the checkout that creates the row.
+            // We can't persist a row without an email (NOT NULL); the checkout event will create it.
+            LOG.warn("Skipping subscription upsert for {} - no existing row and no email", stripeSubscriptionId);
+            return;
+        }
+
+        SubscriptionEntity sub = existing.orElseGet(SubscriptionEntity::new);
+
+        sub.setStripeSubscriptionId(stripeSubscriptionId);
+        if (stripeCustomerId != null) {
+            sub.setStripeCustomerId(stripeCustomerId);
+        }
+        if (email != null) {
+            sub.setEmail(email);
+        }
+        sub.setStatus(status);
+        if (currentPeriodEnd != null) {
+            sub.setCurrentPeriodEnd(currentPeriodEnd);
+        }
+        sub.setCancelAtPeriodEnd(cancelAtPeriodEnd);
+
+        subscriptionRepository.save(sub);
+    }
+
+    private Optional<SubscriptionEntity> mostRecent(String email) {
+        return subscriptionRepository.findByEmailOrderByCreatedAtDesc(email).stream().findFirst();
+    }
+
+    private boolean isActive(SubscriptionEntity sub) {
+        if (!ACTIVE_STATUSES.contains(sub.getStatus())) {
+            return false;
+        }
+        return sub.getCurrentPeriodEnd() == null || sub.getCurrentPeriodEnd().isAfter(LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/hooswhere/letsgogolfing/service/UserSearchPreferenceService.java
+++ b/src/main/java/com/hooswhere/letsgogolfing/service/UserSearchPreferenceService.java
@@ -48,13 +48,29 @@ public class UserSearchPreferenceService {
         SearchCriteriaEntity criteriaEntity = searchCriteriaRepository.findById(criteriaDto.id())
                 .orElseThrow(() -> new IllegalStateException("Search criteria not found after creation"));
 
-        // Create user preference
-        UserSearchPreferenceEntity preference = new UserSearchPreferenceEntity();
+        return upsertPreference(email, criteriaEntity, paymentEnabled, notifyEnabled, scheduleInterval);
+    }
+
+    /**
+     * Reuses the existing (email, search_criteria) row if present (reactivating it), otherwise
+     * inserts a new one. This avoids violating the unique_user_search constraint when a user
+     * re-creates a monitor with the same criteria after it was deactivated.
+     */
+    private UserSearchPreferenceDto upsertPreference(String email,
+                                                     SearchCriteriaEntity criteriaEntity,
+                                                     boolean paymentEnabled,
+                                                     boolean notifyEnabled,
+                                                     Duration scheduleInterval) {
+        UserSearchPreferenceEntity preference = userSearchPreferenceRepository
+                .findByEmailAndSearchCriteriaId(email, criteriaEntity.getId())
+                .orElseGet(UserSearchPreferenceEntity::new);
+
         preference.setEmail(email);
         preference.setSearchCriteria(criteriaEntity);
         preference.setPaymentEnabled(paymentEnabled);
         preference.setNotifyEnabled(notifyEnabled);
         preference.setScheduleInterval(scheduleInterval.toString());  // Store as ISO 8601 string in DB
+        preference.setScheduleId(null);  // reset; set after the new schedule is created
         preference.setActive(true);
 
         UserSearchPreferenceEntity saved = userSearchPreferenceRepository.save(preference);
@@ -75,17 +91,7 @@ public class UserSearchPreferenceService {
         SearchCriteriaEntity criteriaEntity = searchCriteriaRepository.findById(searchCriteriaId)
                 .orElseThrow(() -> new IllegalArgumentException("Search criteria not found: " + searchCriteriaId));
 
-        // Create user preference
-        UserSearchPreferenceEntity preference = new UserSearchPreferenceEntity();
-        preference.setEmail(email);
-        preference.setSearchCriteria(criteriaEntity);
-        preference.setPaymentEnabled(paymentEnabled);
-        preference.setNotifyEnabled(notifyEnabled);
-        preference.setScheduleInterval(scheduleInterval.toString());
-        preference.setActive(true);
-
-        UserSearchPreferenceEntity saved = userSearchPreferenceRepository.save(preference);
-        return toDto(saved);
+        return upsertPreference(email, criteriaEntity, paymentEnabled, notifyEnabled, scheduleInterval);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,4 +30,7 @@ spring.temporal.workersAutoDiscovery.packages=com.hooswhere.letsgogolfing
 
 stripe.webhook.secret=${STRIPE_WEBHOOK_SECRET}
 
+# Base URL of the frontend (Cloudflare Pages), used to build the /connect setup link in emails.
+app.frontend-url=${FRONTEND_URL:http://localhost:5173}
+
 nowgolf.apikey=${NOWGOLF_API_KEY}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -118,12 +118,15 @@ CREATE TABLE IF NOT EXISTS subscriptions (
     email VARCHAR(255) NOT NULL,
     stripe_customer_id VARCHAR(255),
     stripe_subscription_id VARCHAR(255) UNIQUE,
+    stripe_checkout_session_id VARCHAR(255),  -- durable id used to rebuild the /connect link
     status VARCHAR(32) NOT NULL,              -- active, trialing, past_due, canceled, incomplete...
     current_period_end TIMESTAMP,
     cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
     created_at TIMESTAMP NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMP NOT NULL DEFAULT NOW()
 );
+
+ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS stripe_checkout_session_id VARCHAR(255);
 
 CREATE INDEX IF NOT EXISTS idx_subscriptions_email ON subscriptions (email);
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -110,3 +110,33 @@ CREATE TABLE IF NOT EXISTS email_templates (
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
+
+-- Table: subscriptions
+-- Recurring Stripe subscriptions that gate access to the MCP server
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL,
+    stripe_customer_id VARCHAR(255),
+    stripe_subscription_id VARCHAR(255) UNIQUE,
+    status VARCHAR(32) NOT NULL,              -- active, trialing, past_due, canceled, incomplete...
+    current_period_end TIMESTAMP,
+    cancel_at_period_end BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscriptions_email ON subscriptions (email);
+
+-- Table: mcp_tokens
+-- Per-user bearer tokens for authenticating to the MCP server.
+-- Only the SHA-256 hash of the token is stored; the raw token is shown once on issue.
+CREATE TABLE IF NOT EXISTS mcp_tokens (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL,
+    token_hash VARCHAR(128) NOT NULL UNIQUE,
+    revoked BOOLEAN NOT NULL DEFAULT false,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    last_used_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_mcp_tokens_email ON mcp_tokens (email);


### PR DESCRIPTION
## Summary
Backend support for the post-checkout `/connect` onboarding page and Stripe subscription management, plus the earlier MCP subscription-gating work on this branch.

### New in this PR (connect page + recovery)
- **`POST /api/mcp/tokens/issue`** — subscription-gated (402 if inactive); rotates and returns a fresh MCP token. Called by the connect-page worker after verifying a paid Stripe checkout session.
- **`stripe_checkout_session_id`** persisted on `subscriptions` (durable handle for rebuilding the setup link); threaded through `upsertFromStripe`.
- **`POST /api/connect/resend`** — re-emails the `/connect` link to the address on file when it has an active subscription; always returns a generic 200 (no email enumeration).
- **`ConnectEmailService`** — the webhook now links to `/connect?session_id=...` instead of embedding a raw token; the connect page is the single source of truth and issues the token on visit. Hardcoded host replaced with `app.frontend-url` config.
- **Deployment**: `FRONTEND_URL` wired into `pi-deployment/docker-compose.yml` (defaults to `https://app.teetimemonitor.com`). New column auto-applies via `ddl-auto=update`.

## Cancel policy
Existing active monitor runs until its date; only new `create_monitor` calls are blocked (already 402 via subscription gating). No Temporal cancellation on `subscription.deleted`.

## Verification
- `POST /api/mcp/tokens/issue` returns a fresh token and revokes the prior; 402 with no active subscription.
- Subscription checkout → email links to `/connect?session_id=...` (no raw token).
- `/api/connect/resend` emails subscribed addresses only; generic response otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)