### PR TITLE
Enable RLS on subscriptions and mcp_tokens

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -130,6 +130,11 @@ ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS stripe_checkout_session_id VA
 
 CREATE INDEX IF NOT EXISTS idx_subscriptions_email ON subscriptions (email);
 
+-- Lock down PostgREST/anon access: these rows hold Stripe customer ids and gate access.
+-- The app connects as the table owner (bypasses RLS); with RLS on and no policies,
+-- the Supabase anon/authenticated API roles get no access. Idempotent.
+ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY;
+
 -- Table: mcp_tokens
 -- Per-user bearer tokens for authenticating to the MCP server.
 -- Only the SHA-256 hash of the token is stored; the raw token is shown once on issue.
@@ -143,3 +148,6 @@ CREATE TABLE IF NOT EXISTS mcp_tokens (
 );
 
 CREATE INDEX IF NOT EXISTS idx_mcp_tokens_email ON mcp_tokens (email);
+
+-- Token hashes must never be reachable via the public API. Same rationale as subscriptions.
+ALTER TABLE mcp_tokens ENABLE ROW LEVEL SECURITY;


### PR DESCRIPTION
## Problem
`subscriptions` and `mcp_tokens` were auto-created by Hibernate (`ddl-auto=update`) without row-level security, so Supabase flags them **Unrestricted** — they're reachable through the PostgREST API with the anon key. These tables hold Stripe customer ids and SHA-256 token hashes, so this is a real exposure.

## Fix
Add idempotent `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` for both tables in `schema.sql`. With RLS enabled and no policies, the anon/authenticated API roles get zero access. The app connects as the table owner via a direct Postgres connection, which bypasses RLS, so application behavior is unchanged.

## Prod note
For an immediate prod fix (independent of redeploying the app), run the equivalent in the Supabase SQL editor:
```sql
ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
ALTER TABLE public.mcp_tokens   ENABLE ROW LEVEL SECURITY;
```
This PR makes it durable for future/fresh deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)